### PR TITLE
feat: add notification body message & text min-width (#7)

### DIFF
--- a/internal/dbus.go
+++ b/internal/dbus.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -98,7 +100,20 @@ func (n DBusNotify) Notify(
 
 	// Send Notification
 	nf := NewNotification()
-	nf.message = summary
+	if body != "" {
+		nf.message = fmt.Sprintf("%s\n%s", summary, body)
+	} else {
+		nf.message = summary
+	}
+
+	// Using RegExp to add padding for all lines
+	nf.message = regexp.
+		MustCompile("^\\s*|(\n)\\s*(.)").
+		ReplaceAllString(
+			strings.TrimLeft(nf.message, "\n"),
+			"$1\u205F\u205F$2",
+		)
+
 	parse_hints(&nf, hints)
 
 	if expire_timeout != -1 {

--- a/internal/dbus.go
+++ b/internal/dbus.go
@@ -100,6 +100,16 @@ func (n DBusNotify) Notify(
 
 	// Send Notification
 	nf := NewNotification()
+
+	parse_hints(&nf, hints)
+
+	// Setting min-width, left alignment
+	summary = fmt.Sprintf("%-60s", summary)
+	if nf.icon.value == nf.icon.NOICON {
+		summary += "  "
+	}
+	summary += "\u205F"
+
 	if body != "" {
 		nf.message = fmt.Sprintf("%s\n%s", summary, body)
 	} else {
@@ -111,10 +121,8 @@ func (n DBusNotify) Notify(
 		MustCompile("^\\s*|(\n)\\s*(.)").
 		ReplaceAllString(
 			strings.TrimLeft(nf.message, "\n"),
-			"$1\u205F\u205F$2",
+			"$1\u205F $2",
 		)
-
-	parse_hints(&nf, hints)
 
 	if expire_timeout != -1 {
 		nf.time_ms = expire_timeout

--- a/internal/dbus.go
+++ b/internal/dbus.go
@@ -65,11 +65,12 @@ const DBUS_XML = `<node name="` + FDN_PATH + `">
 </node>`
 
 var (
-	conn                  *dbus.Conn
-	hyprsock              HyprConn
-	ongoing_notifications map[uint32]chan uint32 = make(map[uint32]chan uint32)
-	current_id            uint32                 = 0
-	sound                 bool
+	conn                        *dbus.Conn
+	hyprsock                    HyprConn
+	ongoing_notifications       map[uint32]chan uint32 = make(map[uint32]chan uint32)
+	current_id                  uint32                 = 0
+	sound                       bool
+	notification_padding_regexp *regexp.Regexp         = regexp.MustCompile("^\\s*|(\n)\\s*(.)")
 )
 
 type DBusNotify string
@@ -117,8 +118,7 @@ func (n DBusNotify) Notify(
 	}
 
 	// Using RegExp to add padding for all lines
-	nf.message = regexp.
-		MustCompile("^\\s*|(\n)\\s*(.)").
+	nf.message = notification_padding_regexp.
 		ReplaceAllString(
 			strings.TrimLeft(nf.message, "\n"),
 			"$1\u205F $2",

--- a/internal/dbus.go
+++ b/internal/dbus.go
@@ -76,7 +76,7 @@ var (
 type DBusNotify string
 
 func (n DBusNotify) GetCapabilities() ([]string, *dbus.Error) {
-	var cap []string
+	cap := []string{"body"}
 	return cap, nil
 }
 

--- a/internal/notify.go
+++ b/internal/notify.go
@@ -80,27 +80,23 @@ func newIconStruct() icon {
 
 func (nf *Notification) set_urgency(urgency uint8) {
 	icon := nf.icon.NOICON
-	padding := ""
 	color := nf.color.DEFAULT
 	var time_ms int32 = 5 * 1000
 
 	if urgency == 0 {
 		icon = nf.icon.OK
-		padding = " "
 		color = nf.color.GREEN
 	} else if urgency == 1 {
 		icon = nf.icon.NOICON
-		padding = " "
 		color = nf.color.LIGHTBLUE
 	} else if urgency == 2 {
 		icon = nf.icon.WARNING
-		padding = "  "
 		color = nf.color.RED
 		time_ms = 60 * 1000
 	}
 
 	nf.icon.value = icon
-	nf.icon.padding = padding
+	nf.icon.padding = ""
 	nf.color.value = color
 	nf.time_ms = time_ms
 }


### PR DESCRIPTION
Done! It solves #7 issue. Review the PR please.

Added Features:

- Notification body message on a new line when present.
- Notification minimum width, consequently promoting symmetry and left alignment for text.

  I used an invisible character ([\u205F](https://www.compart.com/en/unicode/U+205F)) at the end of the spaces to prevent hyprland from trimming the spaces and making them disappear.

  

**1. Without Body**

![image](https://github.com/user-attachments/assets/6bf0f3eb-3ca9-4956-bc93-5f9e696f0aa4)

**2. With Body**

The notification without an icon is subtly larger than the notifications that have an icon, unfortunately I didn't find better ways to compensate for the lack of an icon.

![image](https://github.com/user-attachments/assets/b5492316-ce7f-4d73-817b-88a277e49041)

> [!IMPORTANT]
> Hyprland default `font-family` must be monospace on `hyprland.conf` misc section. See here: https://wiki.hyprland.org/Configuring/Variables/#misc