### PR TITLE
feat: add `--font-size` & `--fixed-font-size` flags

### DIFF
--- a/cmd/hyprnotify/main.go
+++ b/cmd/hyprnotify/main.go
@@ -19,6 +19,7 @@ func main() {
 	CmdFlags := Cmd.Flags()
 
 	CmdFlags.BoolVarP(&disableSound, "no-sound", "s", false, "disable sound, silent mode")
+	CmdFlags.Uint8VarP(&internal.DefaultFontSize, "font-size", "f", 13, "set default font size (range 1-255)")
 
 	Cmd.Execute()
 }

--- a/cmd/hyprnotify/main.go
+++ b/cmd/hyprnotify/main.go
@@ -20,6 +20,7 @@ func main() {
 
 	CmdFlags.BoolVarP(&disableSound, "no-sound", "s", false, "disable sound, silent mode")
 	CmdFlags.Uint8VarP(&internal.DefaultFontSize, "font-size", "f", 13, "set default font size (range 1-255)")
+	CmdFlags.BoolVar(&internal.FixedFontSize, "fixed-font-size", false, "makes font size fixed, ignoring new sizes")
 
 	Cmd.Execute()
 }

--- a/internal/dbus.go
+++ b/internal/dbus.go
@@ -69,8 +69,8 @@ var (
 	hyprsock                    HyprConn
 	ongoing_notifications       map[uint32]chan uint32 = make(map[uint32]chan uint32)
 	current_id                  uint32                 = 0
-	sound                       bool
 	notification_padding_regexp *regexp.Regexp         = regexp.MustCompile("^\\s*|(\n)\\s*(.)")
+	sound                       bool
 )
 
 type DBusNotify string
@@ -187,7 +187,7 @@ func parse_hints(nf *Notification, hints map[string]dbus.Variant) {
 
 	font_size, ok := hints["x-hyprnotify-font-size"].Value().(int32)
 	if ok {
-		nf.font_size.value = font_size
+		nf.font_size.value = uint8(font_size)
 	}
   
 	hint_icon, ok := hints["x-hyprnotify-icon"].Value().(int32)
@@ -206,8 +206,6 @@ func parse_hints(nf *Notification, hints map[string]dbus.Variant) {
 			nf.color.value = nf.color.HEX(hint_color)
 		}
 	}
-
-
 }
 
 func InitDBus(enable_sound bool) {

--- a/internal/dbus.go
+++ b/internal/dbus.go
@@ -71,6 +71,7 @@ var (
 	current_id                  uint32                 = 0
 	notification_padding_regexp *regexp.Regexp         = regexp.MustCompile("^\\s*|(\n)\\s*(.)")
 	sound                       bool
+	FixedFontSize               bool
 )
 
 type DBusNotify string
@@ -185,16 +186,18 @@ func parse_hints(nf *Notification, hints map[string]dbus.Variant) {
 		nf.set_urgency(urgency)
 	}
 
-	font_size, ok := hints["x-hyprnotify-font-size"].Value().(int32)
-	if ok {
-		nf.font_size.value = uint8(font_size)
+	if !FixedFontSize {
+		font_size, ok := hints["x-hyprnotify-font-size"].Value().(int32)
+		if ok {
+			nf.font_size.value = uint8(font_size)
+		}
 	}
-  
+
 	hint_icon, ok := hints["x-hyprnotify-icon"].Value().(int32)
 	if ok {
 		nf.icon.value = hint_icon
 		nf.icon.padding = ""
-    nf.color.value = nf.color.DEFAULT
+		nf.color.value = nf.color.DEFAULT
 	}
 
 	hint_color, ok := hints["x-hyprnotify-color"].Value().(string)

--- a/internal/hypripc.go
+++ b/internal/hypripc.go
@@ -60,7 +60,7 @@ func (hypr HyprConn) HyprCtl(args ...string) {
 func (hypr HyprConn) SendNotification(nf *Notification) {
 	icon := i32ToString(nf.icon.value)
 	timeout := i32ToString(nf.time_ms)
-	font_size := i32ToString(nf.font_size.value)
+	font_size := fmt.Sprintf("%d", nf.font_size.value)
 	msg := "fontsize:" + font_size + " " + nf.icon.padding + nf.message
 
 	hypr.HyprCtl("notify", icon, timeout, nf.color.value, msg)

--- a/internal/notify.go
+++ b/internal/notify.go
@@ -44,8 +44,7 @@ type icon struct {
 }
 
 type fontSize struct {
-	value   int32
-	DEFAULT int32
+	value uint8
 }
 
 func newColorStruct() color {
@@ -106,7 +105,7 @@ func NewNotification() Notification {
 
 	n.icon = newIconStruct()
 	n.color = newColorStruct()
-	n.font_size = fontSize{value: 13, DEFAULT: 13}
+	n.font_size = fontSize{value: 13}
 
 	n.set_urgency(1) // default
 	return n

--- a/internal/notify.go
+++ b/internal/notify.go
@@ -1,5 +1,7 @@
 package internal
 
+var DefaultFontSize uint8
+
 type Notification struct {
 	message string
 
@@ -105,7 +107,8 @@ func NewNotification() Notification {
 
 	n.icon = newIconStruct()
 	n.color = newColorStruct()
-	n.font_size = fontSize{value: 13}
+
+	n.font_size = fontSize{value: DefaultFontSize}
 
 	n.set_urgency(1) // default
 	return n


### PR DESCRIPTION
```
$ ./hyprnotify --help

DBus Implementation of Freedesktop Notification spec for 'hyprctl notify'

Usage:
  hyprnotify [flags]

Flags:
      --fixed-font-size   makes font size fixed, ignoring new sizes
  -f, --font-size uint8   set default font size (range 1-255) (default 13)
  -h, --help              help for hyprnotify
  -s, --no-sound          disable sound, silent mode
```

My motivation for this PR is that the default font size is very small, this flag not only solves my problem but also makes the size fixed.

Video demo:
https://github.com/user-attachments/assets/bd6a5e4a-6f1d-45eb-9b21-e7d49eb1e70a

