### PR TITLE
Fixed panic when expire_timeout is zero

### DIFF
--- a/internal/dbus.go
+++ b/internal/dbus.go
@@ -129,8 +129,10 @@ func (n DBusNotify) Notify(
 			"$1\u205F $2",
 		)
 
-	if expire_timeout != -1 {
+	if expire_timeout > 0 {
 		nf.time_ms = expire_timeout
+	} else if expire_timeout != -1 {
+		nf.time_ms = 2147483647
 	}
 	hyprsock.SendNotification(&nf)
 


### PR DESCRIPTION
There was an [issue I reported](https://github.com/codelif/hyprnotify/issues/15#issue-4576730510) where hyprnotify would panic when given a expire_timeout of zero. I updated the notify function so that when it gets zero, or any other invalid integer it defaults to the integer limit to make the notification essentially permanent since hyprland seemingly doesn't support permanent notifications.